### PR TITLE
Issue with child contact sensor status not appearing correctly in the app.

### DIFF
--- a/devicetypes/rafaelborja/august-lock-pro-zwave-lock-with-doorsense.src/august-lock-pro-zwave-lock-with-doorsense.groovy
+++ b/devicetypes/rafaelborja/august-lock-pro-zwave-lock-with-doorsense.src/august-lock-pro-zwave-lock-with-doorsense.groovy
@@ -1851,9 +1851,7 @@ private createContactChildDevice() {
 				device.hubId,
 				[completedSetup: true,
 				 label: "${device.displayName} door contact sensor",
-				 isComponent: false,
-				 componentName: "contactsensor",
-				 componentLabel: "door contact sensor"])
+				 isComponent: false])
 	
     log.debug "[DTH] Contact child device added"
     


### PR DESCRIPTION
Fixed an issue with child contact sensor status not appearing correctly in the app. The issue was likely caused by a SmartThings app update. Removed reference to componentName and componentLabel during addChildDevice.

For reference: https://github.com/InovelliUSA/SmartThingsInovelli/commit/68c703e701a0c8920e51c0d89fcbd44837c3253c

Before:
![image](https://user-images.githubusercontent.com/53094348/147860167-2fd2ec19-8a45-4c97-a5c1-66bd4e3a0ac3.png)

After:
![image](https://user-images.githubusercontent.com/53094348/147860169-a79d81b2-30d7-499b-822e-f6f35d821937.png)